### PR TITLE
[fix][sdk] Improve txn retry backoff and fix trace sleep accounting

### DIFF
--- a/src/sdk/common/common.h
+++ b/src/sdk/common/common.h
@@ -147,6 +147,16 @@ static const pb::error::Error& GetRpcResponseError(Rpc& rpc) {
   return *error;
 }
 
+// exponential backoff: retry_times is 1-based, the first retry uses base_ms and
+// each subsequent retry doubles the delay until max_delay_ms
+static int64_t BackoffDelayMs(int64_t base_ms, int64_t retry_times, int64_t max_delay_ms) {
+  int64_t delay_ms = base_ms;
+  for (int64_t i = 1; i < retry_times && delay_ms < max_delay_ms; i++) {
+    delay_ms *= 2;
+  }
+  return delay_ms < max_delay_ms ? delay_ms : max_delay_ms;
+}
+
 static bool IsRetryErrorCode(int32_t error_code) {
   return error_code == pb::error::EREGION_VERSION || error_code == pb::error::EREGION_NOT_FOUND ||
          error_code == pb::error::EKEY_OUT_OF_RANGE || error_code == pb::error::EVECTOR_INDEX_NOT_READY ||

--- a/src/sdk/common/param_config.cc
+++ b/src/sdk/common/param_config.cc
@@ -46,11 +46,15 @@ DEFINE_int64(store_rpc_max_retry, 600, "store rpc max retry times, use case: wro
 
 DEFINE_int64(scan_batch_size, 1000, "scan batch size, use for region scanner");
 
-DEFINE_int64(txn_op_delay_ms, 300, "txn op delay ms");
+DEFINE_int64(txn_op_delay_ms, 5, "txn op initial retry delay ms, doubled per retry up to txn_op_max_delay_ms");
+DEFINE_int64(txn_op_max_delay_ms, 300, "txn op max retry delay ms, upper bound of the exponential backoff");
 DEFINE_int64(txn_op_max_retry, 20, "txn op max retry times");
+DEFINE_int64(txn_resolved_lock_retry_delay_ms, 0, "txn op retry delay ms after lock resolved successfully");
 
 DEFINE_int64(txn_prewrite_delay_ms, 500, "txn prewrite delay ms");
 DEFINE_int64(txn_prewrite_max_retry, 300, "txn prewrite max retry");
+DEFINE_int64(txn_mem_lock_conflict_delay_ms, 5,
+             "retry delay ms on store in-memory lock conflict, the lock is transient so keep it short");
 DEFINE_bool(enable_txn_concurrent_prewrite, true, "enable txn concurrent prewrite");
 
 DEFINE_int64(raw_kv_delay_ms, 500, "raw kv backoff delay ms");
@@ -70,7 +74,7 @@ DEFINE_bool(enable_rocksdb_perf_metric, false, "log response TimeInfo from serve
 DEFINE_int64(txn_heartbeat_interval_ms, 1000, "txn heartbeat interval time");
 DEFINE_int64(txn_heartbeat_lock_delay_ms, 20000, "txn heartbeat lock delay time");
 
-DEFINE_int64(txn_check_status_interval_ms, 100, "txn check status interval ms");
+DEFINE_int64(txn_check_status_interval_ms, 5, "txn check status interval ms");
 
 DEFINE_uint32(stale_period_us, 1000, "stale period us default 1000 us, used for tso provider");
 DEFINE_uint32(tso_batch_size, 256, "tso batch size default 256, used for tso provider");

--- a/src/sdk/common/param_config.h
+++ b/src/sdk/common/param_config.h
@@ -63,10 +63,13 @@ DECLARE_int64(raw_kv_delay_ms);
 DECLARE_int64(raw_kv_max_retry);
 
 DECLARE_int64(txn_op_delay_ms);
+DECLARE_int64(txn_op_max_delay_ms);
 DECLARE_int64(txn_op_max_retry);
+DECLARE_int64(txn_resolved_lock_retry_delay_ms);
 
 DECLARE_int64(txn_prewrite_delay_ms);
 DECLARE_int64(txn_prewrite_max_retry);
+DECLARE_int64(txn_mem_lock_conflict_delay_ms);
 DECLARE_bool(enable_txn_concurrent_prewrite);
 
 DECLARE_int64(vector_op_delay_ms);

--- a/src/sdk/rpc/store_rpc_controller.cc
+++ b/src/sdk/rpc/store_rpc_controller.cc
@@ -127,12 +127,16 @@ void StoreRpcController::SendStoreRpc() {
 
 void StoreRpcController::MaybeDelay() {
   if (NeedDelay(status_)) {
-    auto delay_ms = FLAGS_store_rpc_retry_delay_ms;
+    // store in-memory lock is transient, retry quickly and escalate on repeated conflicts
+    auto delay_ms = status_.IsTxnMemLockConflict()
+                        ? BackoffDelayMs(FLAGS_txn_mem_lock_conflict_delay_ms, rpc_retry_times_,
+                                         FLAGS_store_rpc_retry_delay_ms)
+                        : FLAGS_store_rpc_retry_delay_ms;
     DINGO_LOG(INFO) << fmt::format("[sdk.rpc.{}] txn_id:{} method:{} region({}) sleep {}ms, reason: {}",
                                    rpc_.LogId(), rpc_.GetTxnId(), rpc_.Method(), region_->RegionId(), delay_ms,
                                    status_.ToString());
     rpc_.IncSleepCount();
-    rpc_.IncSleepTimesUs(FLAGS_coordinator_interaction_delay_ms * 1000);
+    rpc_.IncSleepTimesUs(delay_ms * 1000);
     SleepUs(delay_ms * 1000);
   }
 }

--- a/src/sdk/transaction/txn_region_scanner_impl.cc
+++ b/src/sdk/transaction/txn_region_scanner_impl.cc
@@ -166,9 +166,10 @@ Status TxnRegionScannerImpl::SetBatchSize(int64_t size) {
 bool TxnRegionScannerImpl::IsNeedRetry(int& times) {
   bool retry = times++ < FLAGS_txn_op_max_retry;
   if (retry) {
-    uint64_t sleep_us = FLAGS_txn_op_delay_ms * 1000;
+    int64_t delay_ms = BackoffDelayMs(FLAGS_txn_op_delay_ms, times, FLAGS_txn_op_max_delay_ms);
+    uint64_t sleep_us = delay_ms * 1000;
     DINGO_LOG(INFO) << fmt::format("[sdk.txn.{}] sleep {}ms, reason: scan retry({}/{}), region({}).",
-                                   txn_start_ts_, FLAGS_txn_op_delay_ms, times, FLAGS_txn_op_max_retry,
+                                   txn_start_ts_, delay_ms, times, FLAGS_txn_op_max_retry,
                                    region->RegionId());
     SleepUs(sleep_us);
     if (tracker_) {

--- a/src/sdk/transaction/txn_task/txn_batch_get_task.h
+++ b/src/sdk/transaction/txn_task/txn_batch_get_task.h
@@ -35,7 +35,10 @@ class TxnBatchGetTask : public TxnTask {
  public:
   TxnBatchGetTask(const ClientStub& stub, const std::vector<std::string>& key, std::vector<KVPair>& out_kvs,
                   std::shared_ptr<TxnImpl> txn_impl)
-      : TxnTask(stub), keys_(key), out_kvs_(out_kvs), txn_impl_(txn_impl) {}
+      : TxnTask(stub, txn_impl->GetTracer(), txn_impl->GetStartTs()),
+        keys_(key),
+        out_kvs_(out_kvs),
+        txn_impl_(txn_impl) {}
 
   ~TxnBatchGetTask() override = default;
 

--- a/src/sdk/transaction/txn_task/txn_batch_rollback_task.h
+++ b/src/sdk/transaction/txn_task/txn_batch_rollback_task.h
@@ -34,7 +34,7 @@ namespace sdk {
 class TxnBatchRollbackTask : public TxnTask {
  public:
   TxnBatchRollbackTask(const ClientStub& stub, const std::vector<std::string> keys, std::shared_ptr<TxnImpl> txn_impl)
-      : TxnTask(stub), keys_(keys), txn_impl_(txn_impl){}
+      : TxnTask(stub, txn_impl->GetTracer(), txn_impl->GetStartTs()), keys_(keys), txn_impl_(txn_impl) {}
 
   ~TxnBatchRollbackTask() override = default;
 

--- a/src/sdk/transaction/txn_task/txn_commit_task.h
+++ b/src/sdk/transaction/txn_task/txn_commit_task.h
@@ -36,7 +36,10 @@ class TxnCommitTask : public TxnTask {
  public:
   TxnCommitTask(const ClientStub& stub, const std::vector<std::string> keys, std::shared_ptr<TxnImpl> txn_impl,
                 bool is_primary)
-      : TxnTask(stub), keys_(keys), txn_impl_(txn_impl), is_primary_(is_primary) {}
+      : TxnTask(stub, txn_impl->GetTracer(), txn_impl->GetStartTs()),
+        keys_(keys),
+        txn_impl_(txn_impl),
+        is_primary_(is_primary) {}
 
   ~TxnCommitTask() override = default;
 

--- a/src/sdk/transaction/txn_task/txn_get_task.h
+++ b/src/sdk/transaction/txn_task/txn_get_task.h
@@ -31,7 +31,11 @@ namespace sdk {
 class TxnGetTask : public TxnTask {
  public:
   TxnGetTask(const ClientStub& stub, const std::string& key, std::string& value, std::shared_ptr<TxnImpl> txn_impl)
-      : TxnTask(stub), key_(key), value_(value), txn_impl_(txn_impl), store_rpc_controller_(stub, rpc_) {}
+      : TxnTask(stub, txn_impl->GetTracer(), txn_impl->GetStartTs()),
+        key_(key),
+        value_(value),
+        txn_impl_(txn_impl),
+        store_rpc_controller_(stub, rpc_) {}
 
   ~TxnGetTask() override = default;
 

--- a/src/sdk/transaction/txn_task/txn_prewrite_task.cc
+++ b/src/sdk/transaction/txn_task/txn_prewrite_task.cc
@@ -329,7 +329,12 @@ void TxnPrewriteTask::TxnPrewriteRpcCallback(const Status& status, TxnPrewriteRp
 }
 
 void TxnPrewriteTask::BackoffAndRetry() {
-  stub.GetTxnActuator()->Schedule([this] { DoAsync(); }, FLAGS_txn_prewrite_delay_ms);
+  // store in-memory lock is transient, retry quickly and escalate on repeated conflicts
+  int64_t delay_ms =
+      status_.IsTxnMemLockConflict()
+          ? BackoffDelayMs(FLAGS_txn_mem_lock_conflict_delay_ms, retry_count_, FLAGS_txn_op_max_delay_ms)
+          : FLAGS_txn_prewrite_delay_ms;
+  ScheduleRetry(delay_ms);
 }
 
 bool TxnPrewriteTask::IsRetryError() {

--- a/src/sdk/transaction/txn_task/txn_prewrite_task.h
+++ b/src/sdk/transaction/txn_task/txn_prewrite_task.h
@@ -37,7 +37,7 @@ class TxnPrewriteTask : public TxnTask {
                   const std::map<std::string, const TxnMutation*>& mutations, std::shared_ptr<TxnImpl> txn_impl,
                   const std::map<std::string, const TxnMutation*>& mutations_ordinarykeys_for_async_commit,
                   bool& is_one_pc, bool& use_async_commit, uint64_t& min_commit_ts)
-      : TxnTask(stub),
+      : TxnTask(stub, txn_impl->GetTracer(), txn_impl->GetStartTs()),
         primary_key_(primary_key),
         mutations_(mutations),
         txn_impl_(txn_impl),

--- a/src/sdk/transaction/txn_task/txn_task.cc
+++ b/src/sdk/transaction/txn_task/txn_task.cc
@@ -86,7 +86,8 @@ bool TxnTask::NeedRetry() {
 void TxnTask::DoAsyncRetry() {
   retry_count_++;
   if (retry_count_ < FLAGS_txn_op_max_retry) {
-    BackoffAndRetry();
+    // lock already resolved, retry without the failure backoff
+    ScheduleRetry(FLAGS_txn_resolved_lock_retry_delay_ms);
   } else {
     std::string msg = fmt::format("Fail task:{} retry too times:{}, last op : txn resolve lock", Name(), retry_count_);
     status_ = Status::Aborted(status_.Errno(), msg);
@@ -95,7 +96,21 @@ void TxnTask::DoAsyncRetry() {
 }
 
 void TxnTask::BackoffAndRetry() {
-  stub.GetTxnActuator()->Schedule([this] { DoAsync(); }, FLAGS_txn_op_delay_ms);
+  ScheduleRetry(BackoffDelayMs(FLAGS_txn_op_delay_ms, retry_count_, FLAGS_txn_op_max_delay_ms));
+}
+
+void TxnTask::ScheduleRetry(int64_t delay_ms) {
+  if (delay_ms > 0) {
+    DINGO_LOG(INFO) << fmt::format("[sdk.txn.{}] sleep {}ms, reason: task {} backoff retry({}/{}).", txn_id, delay_ms,
+                                   Name(), retry_count_, FLAGS_txn_op_max_retry);
+    if (tracker != nullptr) {
+      tracker->IncrementSleepTime(delay_ms * 1000);
+      tracker->IncrementSleepCount(1);
+    }
+    stub.GetTxnActuator()->Schedule([this] { DoAsync(); }, delay_ms);
+  } else {
+    stub.GetTxnActuator()->Execute([this] { DoAsync(); });
+  }
 }
 
 void TxnTask::FireCallback() {

--- a/src/sdk/transaction/txn_task/txn_task.h
+++ b/src/sdk/transaction/txn_task/txn_task.h
@@ -17,6 +17,7 @@
 
 #include "dingosdk/status.h"
 #include "sdk/client_stub.h"
+#include "sdk/common/tracker.h"
 #include "sdk/utils/callback.h"
 #include "sdk/utils/rw_lock.h"
 #include "sdk/utils/scoped_cleanup.h"
@@ -26,7 +27,8 @@ namespace sdk {
 
 class TxnTask {
  public:
-  TxnTask(const ClientStub& stub) : stub(stub) {}
+  TxnTask(const ClientStub& stub, TrackerPtr tracker = nullptr, int64_t txn_id = 0)
+      : stub(stub), tracker(tracker), txn_id(txn_id) {}
   virtual ~TxnTask() = default;
 
   Status Run();
@@ -44,7 +46,12 @@ class TxnTask {
 
   void DoAsyncRetry();
 
+  // schedule DoAsync after delay_ms; delay is recorded into tracker sleep metrics
+  void ScheduleRetry(int64_t delay_ms);
+
   const ClientStub& stub;
+  TrackerPtr tracker;
+  int64_t txn_id;
 
   // prewrite requires special processing
   virtual void BackoffAndRetry();

--- a/test/unit_test/sdk/test_store_rpc_controller.cc
+++ b/test/unit_test/sdk/test_store_rpc_controller.cc
@@ -375,6 +375,43 @@ TEST_F(SDKStoreRpcControllerTest, RequestFullThenSuccess) {
   EXPECT_EQ(rpc.Response()->value(), "pong");
 }
 
+TEST_F(SDKStoreRpcControllerTest, MemLockConflictThenSuccess) {
+  KvGetRpc rpc;
+  std::string key = "d";
+  rpc.MutableRequest()->set_key(key);
+  std::shared_ptr<Region> region;
+  Status got = meta_cache->LookupRegionByKey(key, region);
+  EXPECT_TRUE(got.IsOK());
+
+  StoreRpcController controller(*stub, rpc, region);
+
+  EXPECT_CALL(*rpc_client, SendRpc)
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* kv_rpc = dynamic_cast<KvGetRpc*>(&rpc);
+        CHECK_NOTNULL(kv_rpc);
+
+        auto* response = kv_rpc->MutableResponse();
+        response->mutable_error()->set_errcode(pb::error::ETXN_MEMORY_LOCK_CONFLICT);
+        cb();
+      })
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        rpc.Reset();
+        auto* kv_rpc = dynamic_cast<KvGetRpc*>(&rpc);
+        CHECK_NOTNULL(kv_rpc);
+        kv_rpc->MutableResponse()->set_value("pong");
+        cb();
+      });
+
+  Status call = controller.Call();
+  EXPECT_TRUE(call.IsOK());
+  EXPECT_EQ(rpc.Response()->value(), "pong");
+
+  // mem lock conflict retries with the short dedicated delay, and the recorded
+  // sleep metric must match the actual delay
+  EXPECT_EQ(rpc.GetSleepCount(), 1);
+  EXPECT_EQ(rpc.GetSleepTimesUs(), FLAGS_txn_mem_lock_conflict_delay_ms * 1000);
+}
+
 TEST_F(SDKStoreRpcControllerTest, OtherErrorCode) {
   std::string key = "d";
 

--- a/test/unit_test/sdk/transaction/test_txn_impl.cc
+++ b/test/unit_test/sdk/transaction/test_txn_impl.cc
@@ -230,6 +230,157 @@ TEST_F(SDKTxnImplTest, BatchGet) {
   }
 }
 
+TEST_F(SDKTxnImplTest, BatchGetLockConflictResolvedRetryImmediately) {
+  std::vector<std::string> keys;
+  keys.emplace_back("b");
+
+  auto txn = NewTransactionImpl(options);
+
+  auto mock_lock = PrepareLockInfo();
+  mock_lock.set_key("b");
+
+  EXPECT_CALL(*rpc_client, SendRpc)
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* txn_rpc = dynamic_cast<TxnBatchGetRpc*>(&rpc);
+        CHECK_NOTNULL(txn_rpc);
+        // first batch get hit lock
+        *txn_rpc->MutableResponse()->mutable_txn_result()->mutable_locked() = mock_lock;
+        cb();
+      })
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* txn_rpc = dynamic_cast<TxnBatchGetRpc*>(&rpc);
+        CHECK_NOTNULL(txn_rpc);
+        auto* kv = txn_rpc->MutableResponse()->add_kvs();
+        kv->set_key("b");
+        kv->set_value("b");
+        cb();
+      });
+
+  EXPECT_CALL(*txn_lock_resolver, ResolveLock)
+      .WillOnce([&](const pb::store::LockInfo& lock_info, int64_t caller_start_ts, bool /*force_sync_commit*/) {
+        EXPECT_TRUE(LockInfoEqual(lock_info, mock_lock));
+        EXPECT_EQ(caller_start_ts, txn->TEST_GetStartTs());
+        return Status::OK();
+      });
+
+  std::vector<KVPair> kvs;
+  Status s = txn->BatchGet(keys, kvs);
+  EXPECT_TRUE(s.ok());
+  ASSERT_EQ(kvs.size(), 1);
+  EXPECT_EQ(kvs[0].value, "b");
+
+  // retry after a successful resolve must not back off
+  EXPECT_EQ(txn->GetTracer()->ReadRetryCount(), 1);
+  EXPECT_EQ(txn->GetTracer()->SleepTime(), 0);
+  EXPECT_EQ(txn->GetTracer()->SleepTimeCount(), 0);
+}
+
+TEST_F(SDKTxnImplTest, BatchGetResolveLockFailBackoffRecorded) {
+  int64_t saved_delay_ms = FLAGS_txn_op_delay_ms;
+  FLAGS_txn_op_delay_ms = 5;
+
+  std::vector<std::string> keys;
+  keys.emplace_back("b");
+
+  auto txn = NewTransactionImpl(options);
+
+  auto mock_lock = PrepareLockInfo();
+  mock_lock.set_key("b");
+
+  EXPECT_CALL(*rpc_client, SendRpc)
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* txn_rpc = dynamic_cast<TxnBatchGetRpc*>(&rpc);
+        CHECK_NOTNULL(txn_rpc);
+        *txn_rpc->MutableResponse()->mutable_txn_result()->mutable_locked() = mock_lock;
+        cb();
+      })
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* txn_rpc = dynamic_cast<TxnBatchGetRpc*>(&rpc);
+        CHECK_NOTNULL(txn_rpc);
+        *txn_rpc->MutableResponse()->mutable_txn_result()->mutable_locked() = mock_lock;
+        cb();
+      })
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* txn_rpc = dynamic_cast<TxnBatchGetRpc*>(&rpc);
+        CHECK_NOTNULL(txn_rpc);
+        auto* kv = txn_rpc->MutableResponse()->add_kvs();
+        kv->set_key("b");
+        kv->set_value("b");
+        cb();
+      });
+
+  EXPECT_CALL(*txn_lock_resolver, ResolveLock)
+      .WillOnce([&](const pb::store::LockInfo& /*lock_info*/, int64_t /*caller_start_ts*/,
+                    bool /*force_sync_commit*/) { return Status::Incomplete(pb::error::EREGION_VERSION, "mock"); })
+      .WillOnce([&](const pb::store::LockInfo& /*lock_info*/, int64_t /*caller_start_ts*/,
+                    bool /*force_sync_commit*/) { return Status::OK(); });
+
+  std::vector<KVPair> kvs;
+  Status s = txn->BatchGet(keys, kvs);
+  EXPECT_TRUE(s.ok());
+  ASSERT_EQ(kvs.size(), 1);
+
+  // the failure-path backoff must be recorded into sleep metrics
+  EXPECT_EQ(txn->GetTracer()->SleepTime(), FLAGS_txn_op_delay_ms * 1000);
+  EXPECT_EQ(txn->GetTracer()->SleepTimeCount(), 1);
+
+  FLAGS_txn_op_delay_ms = saved_delay_ms;
+}
+
+TEST_F(SDKTxnImplTest, BatchGetRetryBackoffEscalates) {
+  int64_t saved_delay_ms = FLAGS_txn_op_delay_ms;
+  FLAGS_txn_op_delay_ms = 5;
+
+  std::vector<std::string> keys;
+  keys.emplace_back("b");
+
+  auto txn = NewTransactionImpl(options);
+
+  auto mock_lock = PrepareLockInfo();
+  mock_lock.set_key("b");
+
+  // three rpcs: locked, locked, success
+  EXPECT_CALL(*rpc_client, SendRpc)
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* txn_rpc = dynamic_cast<TxnBatchGetRpc*>(&rpc);
+        CHECK_NOTNULL(txn_rpc);
+        *txn_rpc->MutableResponse()->mutable_txn_result()->mutable_locked() = mock_lock;
+        cb();
+      })
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* txn_rpc = dynamic_cast<TxnBatchGetRpc*>(&rpc);
+        CHECK_NOTNULL(txn_rpc);
+        *txn_rpc->MutableResponse()->mutable_txn_result()->mutable_locked() = mock_lock;
+        cb();
+      })
+      .WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+        auto* txn_rpc = dynamic_cast<TxnBatchGetRpc*>(&rpc);
+        CHECK_NOTNULL(txn_rpc);
+        auto* kv = txn_rpc->MutableResponse()->add_kvs();
+        kv->set_key("b");
+        kv->set_value("b");
+        cb();
+      });
+
+  // resolve fails twice with a retryable error, both retries go through backoff
+  EXPECT_CALL(*txn_lock_resolver, ResolveLock)
+      .WillOnce([&](const pb::store::LockInfo& /*lock_info*/, int64_t /*caller_start_ts*/,
+                    bool /*force_sync_commit*/) { return Status::Incomplete(pb::error::EREGION_VERSION, "mock"); })
+      .WillOnce([&](const pb::store::LockInfo& /*lock_info*/, int64_t /*caller_start_ts*/,
+                    bool /*force_sync_commit*/) { return Status::Incomplete(pb::error::EREGION_VERSION, "mock"); });
+
+  std::vector<KVPair> kvs;
+  Status s = txn->BatchGet(keys, kvs);
+  EXPECT_TRUE(s.ok());
+  ASSERT_EQ(kvs.size(), 1);
+
+  // exponential backoff: 1st retry 5ms, 2nd retry 10ms
+  EXPECT_EQ(txn->GetTracer()->SleepTime(), (5 + 10) * 1000);
+  EXPECT_EQ(txn->GetTracer()->SleepTimeCount(), 2);
+
+  FLAGS_txn_op_delay_ms = saved_delay_ms;
+}
+
 TEST_F(SDKTxnImplTest, BatchGetFromBuffer) {
   std::vector<KVPair> kvs;
   kvs.push_back({"b", "b"});


### PR DESCRIPTION
1. Record task-level retry backoff into tracker sleep metrics with a "[sdk.txn.{id}] sleep {n}ms" log, so trace components add up to the total time (previously the 300ms backoff after lock resolution was invisible: sleep(0 0) while ~300ms was unaccounted).
2. Retry immediately after a successful lock resolution instead of a fixed 300ms/500ms backoff (new flag txn_resolved_lock_retry_delay_ms, default 0), saving ~300ms per read-path lock conflict.
3. Exponential backoff for failure-path retries: txn_op_delay_ms (now 5) doubles per retry up to new flag txn_op_max_delay_ms (300), keeping a ~4.5s fault-tolerance window with fast first retries. Applied to txn task retry, scan retry, and mem-lock-conflict retries.
4. Use a short dedicated delay (txn_mem_lock_conflict_delay_ms, 5ms) for transient store in-memory lock conflicts instead of 500ms, in both StoreRpcController::MaybeDelay and TxnPrewriteTask::BackoffAndRetry.
5. Fix MaybeDelay recording coordinator_interaction_delay_ms into rpc sleep metrics instead of the actually slept delay.
6. Lower txn_check_status_interval_ms default 100ms -> 5ms to detect the conflicting txn's commit/rollback sooner.