### PR TITLE
[fix][sdk] Fix async commit lost update on swallowed TxnNotFound

### DIFF
--- a/src/sdk/transaction/txn_lock_resolver.cc
+++ b/src/sdk/transaction/txn_lock_resolver.cc
@@ -79,50 +79,11 @@ Status TxnLockResolver::ResolveLock(const pb::store::LockInfo& conflict_lock_inf
     TxnCheckStatusTask task_check_status(stub_, conflict_lock_info.lock_ts(), conflict_lock_info.primary_lock(),
                                          start_ts, txn_status, force_sync_commit, rollback_if_not_exist);
     status = task_check_status.Run();
-    if (!status.ok()) {
-      if (status.IsTxnNotFound()) {
-        // check lock ttl expired
-        int64_t current_ts;
-        Status status1 = stub_.GetTsoProvider()->GenPhysicalTs(2, current_ts);
-        if (!status1.ok()) {
-          return status1;
-        }
-        if (conflict_lock_info.lock_ttl() > current_ts) {
-          // lock ttl not expired, wait and retry
-          DINGO_LOG(INFO) << fmt::format(
-              "[sdk.txn.{}] sleep {}ms, reason: TxnNotFound and lock_ttl({}) > current_ts({}), lock_info({}).",
-              start_ts, FLAGS_txn_check_status_interval_ms, conflict_lock_info.lock_ttl(), current_ts,
-              conflict_lock_info.ShortDebugString());
-          SleepUs(FLAGS_txn_check_status_interval_ms * 1000);
-        } else {
-          // lock ttl expired, next check will rollback txn if not exist
-          rollback_if_not_exist = true;
-        }
-      } else if (status.IsTxnLockConflict()) {
-        // if lock.ts > current_start_ts, return write conflict
-        if (txn_status.primary_lock_info.lock_ts() > start_ts) {
-          return Status::TxnWriteConflict(txn_status.primary_lock_info.ShortDebugString());
-        }
-        // check lock ttl expired
-        int64_t current_ts;
-        Status status1 = stub_.GetTsoProvider()->GenPhysicalTs(2, current_ts);
-        if (!status1.ok()) {
-          return status1;
-        }
-        if (txn_status.primary_lock_info.lock_ts() > 0 && txn_status.primary_lock_info.lock_ttl() > current_ts) {
-          // lock ttl not expired, wait and retry
-          DINGO_LOG(INFO) << fmt::format(
-              "[sdk.txn.{}] sleep {}ms, reason: TxnLockConflict and lock_ttl({}) > current_ts({}), lock_info({}).",
-              start_ts, FLAGS_txn_check_status_interval_ms, txn_status.primary_lock_info.lock_ttl(), current_ts,
-              txn_status.primary_lock_info.ShortDebugString());
-          SleepUs(FLAGS_txn_check_status_interval_ms * 1000);
-        }
-      } else {
-        return status;
-      }
-    } else {
-      // Save the definitive state to the cache and perform LRU eviction
-      if (txn_status.IsCommitted() || txn_status.IsRollbacked()) {
+    if (status.ok()) {
+      // Save the definitive state to the cache and perform LRU eviction.
+      // A state that still carries a live lock (e.g. an async commit primary lock reported
+      // via txn_result) is not definitive and must not be cached.
+      if ((txn_status.IsCommitted() || txn_status.IsRollbacked()) && txn_status.primary_lock_info.lock_ts() == 0) {
         WriteLockGuard guard(cache_rw_lock_);
         if (resolved_lock_cache_.find(conflict_lock_ts) == resolved_lock_cache_.end()) {
           // insert into LRU if not present
@@ -140,14 +101,47 @@ Status TxnLockResolver::ResolveLock(const pb::store::LockInfo& conflict_lock_inf
       }
       break;
     }
+
+    if (!status.IsTxnNotFound()) {
+      DINGO_LOG(WARNING) << fmt::format("[sdk.txn.{}] check primary lock status fail, lock_info({}), status({}).",
+                                        start_ts, conflict_lock_info.ShortDebugString(), status.ToString());
+      return status;
+    }
+
+    // TxnNotFound: the primary has neither a lock nor a commit/rollback record, the txn may
+    // still be prewriting (e.g. primary prewrite retrying after a region epoch change), so
+    // no lock may be removed based on this result.
+    int64_t current_ts;
+    Status status1 = stub_.GetTsoProvider()->GenPhysicalTs(2, current_ts);
+    if (!status1.ok()) {
+      return status1;
+    }
+    if (conflict_lock_info.lock_ttl() > current_ts) {
+      // lock ttl not expired, wait in place and re-check
+      DINGO_LOG(INFO) << fmt::format(
+          "[sdk.txn.{}] sleep {}ms, reason: TxnNotFound and lock_ttl({}) > current_ts({}), lock_info({}).", start_ts,
+          FLAGS_txn_check_status_interval_ms, conflict_lock_info.lock_ttl(), current_ts,
+          conflict_lock_info.ShortDebugString());
+      SleepUs(FLAGS_txn_check_status_interval_ms * 1000);
+    } else if (!rollback_if_not_exist) {
+      // Lock ttl expired: ask the store to durably write a rollback record on the primary
+      // if the txn still does not exist, only then may the conflict lock be removed.
+      rollback_if_not_exist = true;
+    } else {
+      // The store keeps reporting txn_not_found even with rollback_if_not_exist, bail out
+      // fail-closed without touching any lock.
+      DINGO_LOG(WARNING) << fmt::format(
+          "[sdk.txn.{}] check status still TxnNotFound with rollback_if_not_exist, lock_info({}).", start_ts,
+          conflict_lock_info.ShortDebugString());
+      return status;
+    }
     retry_times++;
   }
 
   if (!status.ok()) {
     DINGO_LOG(WARNING) << fmt::format(
         "[sdk.txn.{}] check primary lock status fail, retry_times({}), max_retry_times({}), interval_ms({}) "
-        "rollback_if_not_exist({}), "
-        "lock_info({}), status({}).",
+        "rollback_if_not_exist({}), lock_info({}), status({}).",
         start_ts, retry_times, max_retry_times, FLAGS_txn_check_status_interval_ms, rollback_if_not_exist,
         conflict_lock_info.ShortDebugString(), status.ToString());
     return status;
@@ -169,8 +163,9 @@ Status TxnLockResolver::ResolveNormalLock(const pb::store::LockInfo& lock_info, 
     return Status::PushMinCommitTs("push min_commit_ts");
   }
 
-  // Although lock push min commit_ts, the lock is still active.
-  if (txn_status.IsLocked()) {
+  // Although lock push min commit_ts, the lock is still active. A primary lock reported via
+  // txn_result also means the txn is alive even if the top-level ttl/commit_ts are unset.
+  if (txn_status.IsLocked() || (txn_status.commit_ts <= 0 && txn_status.primary_lock_info.lock_ts() > 0)) {
     return Status::TxnLockConflict(fmt::format("lock still exist, lock_info({})", lock_info.ShortDebugString()));
   }
 
@@ -208,27 +203,28 @@ Status TxnLockResolver::ResolveLockSecondaryLocks(const pb::store::LockInfo& pri
                                                   const pb::store::LockInfo& conflict_lock_info) {
   DINGO_LOG(DEBUG) << fmt::format("[sdk.txn.{}] lock use async commit, lock_info({}), txn_status({}).", start_ts,
                                   primary_lock_info.ShortDebugString(), txn_status.ToString());
-  //  check lock ttl expired
-  // int64_t retry_times = 0;
-  // int64_t max_retry_times = (FLAGS_txn_heartbeat_lock_delay_ms / FLAGS_txn_check_status_interval_ms) + 1;
-  // while (retry_times < max_retry_times) {
-  //   int64_t current_ts;
-  //   Status status1 = stub_.GetTsoProvider()->GenPhysicalTs(2, current_ts);
-  //   if (!status1.ok()) {
-  //     return status1;
-  //   }
-  //   if (txn_status.primary_lock_info.lock_ttl() > current_ts) {
-  //     // lock ttl not expired, can not resolve lock now
-  //     DINGO_LOG(DEBUG) << fmt::format(
-  //         "[sdk.txn.{}] async commit lock ttl not expired, lock_info({}), txn_status({}), current_ts({}).", start_ts,
-  //         primary_lock_info.ShortDebugString(), txn_status.ToString(), current_ts);
 
-  //     retry_times++;
-  //     SleepUs(FLAGS_txn_check_status_interval_ms * 1000);
-  //     continue;
-  //   }
-  //   break;
-  // }
+  // The store pushed the txn's min_commit_ts above the caller's start_ts: a snapshot read can
+  // safely proceed without waiting for this lock, same as the normal lock path.
+  if (txn_status.IsMinCommitTSPushed()) {
+    return Status::PushMinCommitTs("push min_commit_ts");
+  }
+
+  // Only resolve an async commit txn whose primary lock ttl has expired: a live txn may still
+  // be prewriting, and breaking one of its locks would let it pass the commit point while a
+  // key is already rolled back (partial commit / lost update).
+  int64_t current_ts;
+  Status status1 = stub_.GetTsoProvider()->GenPhysicalTs(2, current_ts);
+  if (!status1.ok()) {
+    return status1;
+  }
+  if (primary_lock_info.lock_ttl() > current_ts) {
+    DINGO_LOG(INFO) << fmt::format(
+        "[sdk.txn.{}] async commit lock ttl not expired, can not resolve now, lock_info({}), current_ts({}).",
+        start_ts, primary_lock_info.ShortDebugString(), current_ts);
+    return Status::TxnLockConflict(
+        fmt::format("async commit primary lock alive, lock_info({})", primary_lock_info.ShortDebugString()));
+  }
 
   // check secondary locks status
   TxnSecondaryLockStatus txn_secondary_lock_status;

--- a/src/sdk/transaction/txn_task/txn_check_status_task.cc
+++ b/src/sdk/transaction/txn_task/txn_check_status_task.cc
@@ -84,16 +84,20 @@ void TxnCheckStatusTask::TxnCheckStatusRpcCallback(const Status& status) {
             "txn_result({}).",
             start_ts_, StringToHex(primary_key_), rpc_.Request()->lock_ts(), rpc_.Request()->caller_start_ts(),
             status.ToString(), txn_result.ShortDebugString());
-        // if (!status.IsTxnLockConflict()) {
-        //   status_ = status;
-        // }
+        // A locked result means the txn is alive, which is a normal state conveyed via
+        // txn_status_; every other txn result (TxnNotFound, PrimaryMismatch, ...) must
+        // be propagated so that the resolver never mistakes an in-flight txn for a
+        // rollbacked one (otherwise it may break a live txn's locks and lose updates).
+        if (!status.IsTxnLockConflict()) {
+          status_ = status;
+        }
       }
     }
   }
 
-  // if (status_.ok()) {
-  txn_status_ = TxnStatus(response->lock_ttl(), response->commit_ts(), response->action(), lock_info);
-  //}
+  if (status_.ok()) {
+    txn_status_ = TxnStatus(response->lock_ttl(), response->commit_ts(), response->action(), lock_info);
+  }
 
   DoAsyncDone(status_);
 }

--- a/src/sdk/transaction/txn_task/txn_get_task.cc
+++ b/src/sdk/transaction/txn_task/txn_get_task.cc
@@ -31,6 +31,9 @@ void TxnGetTask::DoAsync() {
   auto start_time = TimestampUs();
   SCOPED_CLEANUP(txn_impl_->GetTracer()->IncrementReadSdkTime(TimestampUs() - start_time););
 
+  // reset per attempt, a clean response of a retry must not inherit the previous error
+  status_ = Status::OK();
+
   auto meta_cache = stub.GetMetaCache();
   RegionPtr region;
   Status s = meta_cache->LookupRegionByKey(key_, region);

--- a/test/unit_test/sdk/transaction/test_txn_lock_resolver.cc
+++ b/test/unit_test/sdk/transaction/test_txn_lock_resolver.cc
@@ -14,6 +14,7 @@
 
 #include <glog/logging.h>
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -1422,6 +1423,218 @@ TEST_F(SDKTxnLockResolverTest, TxnNotFoundTTLExpired) {
 
   Status s = lock_resolver->ResolveLock(fake_lock, Tso2Timestamp(init_tso));
   EXPECT_TRUE(s.ok());
+}
+
+TEST_F(SDKTxnLockResolverTest, TxnNotFoundLockNotExpiredNotResolved) {
+  // Regression for async-commit lost update: the writer's primary prewrite is delayed
+  // (e.g. region epoch mismatch backoff retry), so CheckTxnStatus returns txn_not_found
+  // while the conflict lock TTL is still alive. The resolver must NOT roll back any
+  // lock; it waits in place and re-checks until its loop bound, then reports TxnNotFound.
+  int64_t saved_lock_delay_ms = FLAGS_txn_heartbeat_lock_delay_ms;
+  int64_t saved_interval_ms = FLAGS_txn_check_status_interval_ms;
+  // shrink the in-resolver wait loop bound (max_retry_times = delay / interval + 1)
+  FLAGS_txn_heartbeat_lock_delay_ms = 20;
+  FLAGS_txn_check_status_interval_ms = 1;
+
+  std::string key = "b";
+  auto fake_lock = PrepareLockInfo();
+  fake_lock.set_key(key);
+  CHECK(fake_lock.lock_ttl() == INT64_MAX);  // lock ttl not expired
+
+  std::shared_ptr<Region> region;
+  CHECK(meta_cache->LookupRegionByKey(fake_lock.primary_lock(), region).IsOK());
+  CHECK_NOTNULL(region.get());
+
+  EXPECT_CALL(*tso_rpc_controller, SyncCall).WillRepeatedly([&](Rpc& rpc) {
+    auto* t_rpc = dynamic_cast<TsoServiceRpc*>(&rpc);
+    EXPECT_EQ(t_rpc->Request()->op_type(), pb::meta::OP_GEN_TSO);
+    t_rpc->MutableResponse()->set_count(FLAGS_tso_batch_size);
+    auto* ts = t_rpc->MutableResponse()->mutable_start_timestamp();
+    *ts = CurrentFakeTso();
+
+    return Status::OK();
+  });
+
+  std::atomic<int> check_rpc_count{0};
+  std::atomic<int> other_rpc_count{0};
+  EXPECT_CALL(*rpc_client, SendRpc).WillRepeatedly([&](Rpc& rpc, std::function<void()> cb) {
+    auto* txn_rpc = dynamic_cast<TxnCheckTxnStatusRpc*>(&rpc);
+    if (txn_rpc != nullptr) {
+      check_rpc_count++;
+      // ttl not expired, must not ask the store to rollback
+      EXPECT_EQ(txn_rpc->Request()->rollback_if_not_exist(), false);
+      auto* no_txn = txn_rpc->MutableResponse()->mutable_txn_result()->mutable_txn_not_found();
+      no_txn->set_start_ts(txn_rpc->Request()->lock_ts());
+      no_txn->set_primary_key(txn_rpc->Request()->primary_key());
+    } else {
+      // any other rpc (e.g. TxnResolveLockRpc) would touch the live txn's locks
+      other_rpc_count++;
+    }
+    cb();
+  });
+
+  Status s = lock_resolver->ResolveLock(fake_lock, Tso2Timestamp(init_tso));
+  EXPECT_TRUE(s.IsTxnNotFound()) << s.ToString();
+  // waited in place and re-checked more than once
+  EXPECT_GE(check_rpc_count.load(), 2);
+  EXPECT_EQ(other_rpc_count.load(), 0);
+
+  FLAGS_txn_heartbeat_lock_delay_ms = saved_lock_delay_ms;
+  FLAGS_txn_check_status_interval_ms = saved_interval_ms;
+}
+
+TEST_F(SDKTxnLockResolverTest, TxnNotFoundEscalatedStillNotFound) {
+  // Conflict lock ttl expired: the resolver escalates with rollback_if_not_exist=true so
+  // the store durably rollbacks the primary first. If the store still reports
+  // txn_not_found after the escalated check, bail out fail-closed without touching locks.
+  std::string key = "b";
+  auto fake_lock = PrepareLockInfo();
+  fake_lock.set_key(key);
+  fake_lock.set_lock_ttl(0);  // lock ttl expired
+
+  std::shared_ptr<Region> region;
+  CHECK(meta_cache->LookupRegionByKey(fake_lock.primary_lock(), region).IsOK());
+  CHECK_NOTNULL(region.get());
+
+  EXPECT_CALL(*tso_rpc_controller, SyncCall).WillRepeatedly([&](Rpc& rpc) {
+    auto* t_rpc = dynamic_cast<TsoServiceRpc*>(&rpc);
+    EXPECT_EQ(t_rpc->Request()->op_type(), pb::meta::OP_GEN_TSO);
+    t_rpc->MutableResponse()->set_count(FLAGS_tso_batch_size);
+    auto* ts = t_rpc->MutableResponse()->mutable_start_timestamp();
+    *ts = CurrentFakeTso();
+
+    return Status::OK();
+  });
+
+  std::atomic<int> check_rpc_count{0};
+  std::atomic<int> other_rpc_count{0};
+  EXPECT_CALL(*rpc_client, SendRpc).WillRepeatedly([&](Rpc& rpc, std::function<void()> cb) {
+    auto* txn_rpc = dynamic_cast<TxnCheckTxnStatusRpc*>(&rpc);
+    if (txn_rpc != nullptr) {
+      int count = ++check_rpc_count;
+      // first probe without rollback, the escalated one with rollback
+      EXPECT_EQ(txn_rpc->Request()->rollback_if_not_exist(), count > 1);
+      auto* no_txn = txn_rpc->MutableResponse()->mutable_txn_result()->mutable_txn_not_found();
+      no_txn->set_start_ts(txn_rpc->Request()->lock_ts());
+      no_txn->set_primary_key(txn_rpc->Request()->primary_key());
+    } else {
+      other_rpc_count++;
+    }
+    cb();
+  });
+
+  Status s = lock_resolver->ResolveLock(fake_lock, Tso2Timestamp(init_tso));
+  EXPECT_TRUE(s.IsTxnNotFound()) << s.ToString();
+  EXPECT_EQ(check_rpc_count.load(), 2);
+  EXPECT_EQ(other_rpc_count.load(), 0);
+}
+
+TEST_F(SDKTxnLockResolverTest, AsyncCommitCaseMinCommitTsPushed) {
+  // The store pushed the async commit txn's min_commit_ts above the reader's start_ts:
+  // the reader can proceed without waiting for the live lock.
+  std::string key = "b0000000";
+  auto fake_lock = PrepareAsyncCommitOrdinaryLockInfo();
+  fake_lock.set_key(key);
+
+  std::shared_ptr<Region> region;
+  CHECK(meta_cache->LookupRegionByKey(fake_lock.primary_lock(), region).IsOK());
+  CHECK_NOTNULL(region.get());
+
+  EXPECT_CALL(*tso_rpc_controller, SyncCall).WillRepeatedly([&](Rpc& rpc) {
+    auto* t_rpc = dynamic_cast<TsoServiceRpc*>(&rpc);
+    EXPECT_EQ(t_rpc->Request()->op_type(), pb::meta::OP_GEN_TSO);
+    t_rpc->MutableResponse()->set_count(FLAGS_tso_batch_size);
+    auto* ts = t_rpc->MutableResponse()->mutable_start_timestamp();
+    *ts = CurrentFakeTso();
+
+    return Status::OK();
+  });
+
+  EXPECT_CALL(*rpc_client, SendRpc).WillOnce([&](Rpc& rpc, std::function<void()> cb) {
+    auto* txn_rpc = dynamic_cast<TxnCheckTxnStatusRpc*>(&rpc);
+    CHECK_NOTNULL(txn_rpc);
+
+    const auto* request = txn_rpc->Request();
+    EXPECT_EQ(request->primary_key(), fake_lock.primary_lock());
+    EXPECT_EQ(request->lock_ts(), fake_lock.lock_ts());
+
+    // live async commit primary lock, min_commit_ts pushed for the caller
+    txn_rpc->MutableResponse()->set_action(pb::store::MinCommitTSPushed);
+    auto* lock_info = txn_rpc->MutableResponse()->mutable_txn_result()->mutable_locked();
+    lock_info->set_key("a0000000");
+    lock_info->set_primary_lock("a0000000");
+    lock_info->set_lock_ts(1);
+    lock_info->set_lock_ttl(INT64_MAX);
+    lock_info->set_txn_size(1);
+    lock_info->set_lock_type(pb::store::Op::Put);
+    lock_info->set_use_async_commit(true);
+    lock_info->set_min_commit_ts(10);
+    lock_info->add_secondaries("b0000000");
+    lock_info->add_secondaries("d0000000");
+    lock_info->add_secondaries("f0000000");
+
+    cb();
+  });
+
+  Status s = lock_resolver->ResolveLock(fake_lock, Tso2Timestamp(init_tso));
+  EXPECT_TRUE(s.IsPushMinCommitTs()) << s.ToString();
+}
+
+TEST_F(SDKTxnLockResolverTest, TxnNotFoundNotCached) {
+  // A txn_not_found probe result is not a definitive txn state, it must not be cached:
+  // a second ResolveLock for the same lock_ts has to re-check the primary lock status.
+  int64_t saved_lock_delay_ms = FLAGS_txn_heartbeat_lock_delay_ms;
+  int64_t saved_interval_ms = FLAGS_txn_check_status_interval_ms;
+  // shrink the in-resolver wait loop bound (max_retry_times = delay / interval + 1)
+  FLAGS_txn_heartbeat_lock_delay_ms = 20;
+  FLAGS_txn_check_status_interval_ms = 1;
+
+  std::string key = "b";
+  auto fake_lock = PrepareLockInfo();
+  fake_lock.set_key(key);
+  CHECK(fake_lock.lock_ttl() == INT64_MAX);  // lock ttl not expired
+
+  std::shared_ptr<Region> region;
+  CHECK(meta_cache->LookupRegionByKey(fake_lock.primary_lock(), region).IsOK());
+  CHECK_NOTNULL(region.get());
+
+  EXPECT_CALL(*tso_rpc_controller, SyncCall).WillRepeatedly([&](Rpc& rpc) {
+    auto* t_rpc = dynamic_cast<TsoServiceRpc*>(&rpc);
+    EXPECT_EQ(t_rpc->Request()->op_type(), pb::meta::OP_GEN_TSO);
+    t_rpc->MutableResponse()->set_count(FLAGS_tso_batch_size);
+    auto* ts = t_rpc->MutableResponse()->mutable_start_timestamp();
+    *ts = CurrentFakeTso();
+
+    return Status::OK();
+  });
+
+  std::atomic<int> check_rpc_count{0};
+  std::atomic<int> other_rpc_count{0};
+  EXPECT_CALL(*rpc_client, SendRpc).WillRepeatedly([&](Rpc& rpc, std::function<void()> cb) {
+    auto* txn_rpc = dynamic_cast<TxnCheckTxnStatusRpc*>(&rpc);
+    if (txn_rpc != nullptr) {
+      check_rpc_count++;
+      auto* no_txn = txn_rpc->MutableResponse()->mutable_txn_result()->mutable_txn_not_found();
+      no_txn->set_start_ts(txn_rpc->Request()->lock_ts());
+      no_txn->set_primary_key(txn_rpc->Request()->primary_key());
+    } else {
+      other_rpc_count++;
+    }
+    cb();
+  });
+
+  Status s1 = lock_resolver->ResolveLock(fake_lock, Tso2Timestamp(init_tso));
+  EXPECT_TRUE(s1.IsTxnNotFound()) << s1.ToString();
+  int checks_after_first = check_rpc_count.load();
+  EXPECT_GE(checks_after_first, 1);
+
+  Status s2 = lock_resolver->ResolveLock(fake_lock, Tso2Timestamp(init_tso));
+  EXPECT_TRUE(s2.IsTxnNotFound()) << s2.ToString();
+  EXPECT_GT(check_rpc_count.load(), checks_after_first);
+  EXPECT_EQ(other_rpc_count.load(), 0);
+
+  FLAGS_txn_heartbeat_lock_delay_ms = saved_lock_delay_ms;
+  FLAGS_txn_check_status_interval_ms = saved_interval_ms;
 }
 
 }  // namespace sdk


### PR DESCRIPTION
CheckTxnStatus errors were swallowed and the empty response was turned into TxnStatus{lock_ttl=0, commit_ts=0}, which satisfies IsRollbacked(). A resolver hitting a lock whose primary prewrite was still retrying (e.g. region epoch change backoff) treated the live txn as rolled back and removed its secondary lock without any durable rollback record on the primary. The writer's prewrite retry then succeeded, the async commit point was reached and success was returned to the client, while the background commit hit SelfRolledBack on that key: partial commit and silent lost update.

- txn_check_status_task: restore error propagation (locked stays a normal state) and only fill txn_status_ from a successful response.
- ResolveLock: on TxnNotFound wait in place while the conflict lock ttl is alive; after ttl expiry escalate rollback_if_not_exist once so the store durably rollbacks the primary before any lock is removed; bail out fail-closed if the store still reports txn_not_found; drop the dead TxnLockConflict branch; do not cache states that still carry a live lock.
- ResolveNormalLock: a lock reported via txn_result means the txn is alive even if the top-level ttl/commit_ts fields are unset.
- ResolveLockSecondaryLocks: pass through MinCommitTSPushed for readers and only run the async commit resolution after the primary lock ttl has expired.
- TxnGetTask::DoAsync: reset status_ per attempt so a clean retry response does not inherit the previous error.